### PR TITLE
Replace deprecated $app/stores usage

### DIFF
--- a/src/lib/components/BottomNavigation.svelte
+++ b/src/lib/components/BottomNavigation.svelte
@@ -5,7 +5,7 @@
 	import MdiNotificationsNone from '~icons/mdi/notifications-none';
 	import MdiAdd from '~icons/mdi/add';
 	import { goto } from '$app/navigation';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { getNotificationsState } from '$lib/states/notifications.svelte';
 
 	const notificationsState = getNotificationsState();
@@ -32,7 +32,7 @@
 	];
 	let selectedTab = $state(-1);
 	$effect(() => {
-		const currentTab = tabs.findIndex((tab) => tab.pathName === $page?.url?.pathname);
+		const currentTab = tabs.findIndex((tab) => tab.pathName === page?.url?.pathname);
 		selectedTab = currentTab !== -1 ? currentTab : -1; // Default to -1 if no match is found
 	});
 </script>
@@ -45,7 +45,7 @@
 
 	<div class="indicator">
 		<span
-			class="indicator-item badge badge-primary"
+			class="badge indicator-item badge-primary"
 			class:hidden={!notificationsState.notifications.find((notification) => notification?.new)}
 			>{notificationsState.notifications.filter((notification) => notification?.new).length}</span
 		>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 </script>
 
-<h1 class="text-center text-xl">{$page?.status} - {$page?.error?.message}</h1>
+<h1 class="text-center text-xl">{page?.status} - {page?.error?.message}</h1>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
 	import { type Snippet } from 'svelte';
 	import { setThemeState } from '$lib/states/theme.svelte';
 	import { PUBLIC_APP_NAME } from '$env/static/public';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	setThemeState();
 	let {
 		children,
@@ -15,8 +15,6 @@
 </script>
 
 <svelte:head>
-	<title
-		>{$page?.data?.title ? `${PUBLIC_APP_NAME} - ${$page?.data?.title}` : PUBLIC_APP_NAME}</title
-	>
+	<title>{page?.data?.title ? `${PUBLIC_APP_NAME} - ${page?.data?.title}` : PUBLIC_APP_NAME}</title>
 </svelte:head>
 {@render children()}


### PR DESCRIPTION
`$app/stores` is deprecated as of [SvelteKit 2.12](https://svelte.dev/docs/kit/migrating-to-sveltekit-2#SvelteKit-2.12:-$app-stores-deprecated).

Replaced the `$app/stores` imports with `$app/state` and removed `$` prefixes.